### PR TITLE
fix: add spaces to the "command expected at line"'s

### DIFF
--- a/lib/bytecode_parser/scenarios/FunctionParser.cpp
+++ b/lib/bytecode_parser/scenarios/FunctionParser.cpp
@@ -104,7 +104,7 @@ std::expected<bool, BytecodeParserError> FunctionParser::Handle(ParsingSessionPt
       return res;
     } else if (!res.value()) {
       return std::unexpected(
-          BytecodeParserError("Command expected at line" + std::to_string(ctx->Current()->GetPosition().GetLine())));
+          BytecodeParserError("Command expected at line " + std::to_string(ctx->Current()->GetPosition().GetLine())));
     }
   }
 

--- a/lib/bytecode_parser/scenarios/IfParser.cpp
+++ b/lib/bytecode_parser/scenarios/IfParser.cpp
@@ -40,7 +40,7 @@ std::expected<bool, BytecodeParserError> IfParser::Handle(std::shared_ptr<Parsin
       return res;
     } else if (!res.value()) {
       return std::unexpected(
-          BytecodeParserError("Command expected at line" + std::to_string(ctx->Current()->GetPosition().GetLine())));
+          BytecodeParserError("Command expected at line " + std::to_string(ctx->Current()->GetPosition().GetLine())));
     }
   }
 
@@ -73,7 +73,7 @@ std::expected<bool, BytecodeParserError> IfParser::Handle(std::shared_ptr<Parsin
       return res;
     } else if (!res.value()) {
       return std::unexpected(
-          BytecodeParserError("Command expected at line" + std::to_string(ctx->Current()->GetPosition().GetLine())));
+          BytecodeParserError("Command expected at line " + std::to_string(ctx->Current()->GetPosition().GetLine())));
     }
   }
 
@@ -107,7 +107,7 @@ std::expected<bool, BytecodeParserError> IfParser::Handle(std::shared_ptr<Parsin
         if (!res) {
           return res;
         } else if (!res.value()) {
-          return std::unexpected(BytecodeParserError("Command expected at line" +
+          return std::unexpected(BytecodeParserError("Command expected at line " +
                                                      std::to_string(ctx->Current()->GetPosition().GetLine())));
         }
       }
@@ -140,7 +140,7 @@ std::expected<bool, BytecodeParserError> IfParser::Handle(std::shared_ptr<Parsin
         if (!res) {
           return res;
         } else if (!res.value()) {
-          return std::unexpected(BytecodeParserError("Command expected at line" +
+          return std::unexpected(BytecodeParserError("Command expected at line " +
                                                      std::to_string(ctx->Current()->GetPosition().GetLine())));
         }
       }

--- a/lib/bytecode_parser/scenarios/InitStaticParser.cpp
+++ b/lib/bytecode_parser/scenarios/InitStaticParser.cpp
@@ -38,7 +38,7 @@ std::expected<bool, BytecodeParserError> InitStaticParser::Handle(ParsingSession
       return res;
     } else if (!res.value()) {
       return std::unexpected(
-          BytecodeParserError("Command expected at line" + std::to_string(ctx->Current()->GetPosition().GetLine())));
+          BytecodeParserError("Command expected at line " + std::to_string(ctx->Current()->GetPosition().GetLine())));
     }
   }
 

--- a/lib/bytecode_parser/scenarios/WhileParser.cpp
+++ b/lib/bytecode_parser/scenarios/WhileParser.cpp
@@ -39,7 +39,7 @@ std::expected<bool, BytecodeParserError> WhileParser::Handle(std::shared_ptr<Par
     } else if (!res.value()) {
       ctx->SetCurrentBlock(parent_block);
       return std::unexpected(
-          BytecodeParserError("Command expected at line" + std::to_string(ctx->Current()->GetPosition().GetLine())));
+          BytecodeParserError("Command expected at line " + std::to_string(ctx->Current()->GetPosition().GetLine())));
     }
   }
 
@@ -77,7 +77,7 @@ std::expected<bool, BytecodeParserError> WhileParser::Handle(std::shared_ptr<Par
     } else if (!res.value()) {
       ctx->SetCurrentBlock(parent_block);
       return std::unexpected(
-          BytecodeParserError("Command expected at line" + std::to_string(ctx->Current()->GetPosition().GetLine())));
+          BytecodeParserError("Command expected at line " + std::to_string(ctx->Current()->GetPosition().GetLine())));
     }
   }
 


### PR DESCRIPTION
"Command expected at line" do have spaces after them, while other errors do have those:

[Source](https://github.com/Ovum-Programming-Language/OvumVM/blob/master/lib/bytecode_parser/BytecodeParser.cpp)

```cpp
if (!handled) {
  TokenPtr token = session->Current();
  std::string message = "Unknown top-level declaration: " + token->GetLexeme() + " at line " +
                        std::to_string(token->GetPosition().GetLine()) + " column " +
                        std::to_string(token->GetPosition().GetColumn());

  return std::unexpected(BytecodeParserError(message));
}
```

That results in text concatenation:

```sh
➜  TestOvum ovumc -m main.ovum -o main.oil && ovum-vm -f main.oil
Parser error: Command expected at line11
```

Fixed:

```sh
➜  TestOvum ovumc -m main.ovum -o main.oil && ovum-vm -f main.oil
Parser error: Command expected at line 11
```
